### PR TITLE
Upgrade versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,7 @@ script:
   - docker build -t "$image" .
   - ~/official-images/test/run.sh "$image"
 
+after_script:
+  - docker images
+
 # vim:set et ts=2 sw=2:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: bash
+
+# for secret experimental features ;)
+sudo: 9000
+
+env:
+  - VERSION=1.7
+  - VERSION=1.6
+  - VERSION=1.5
+  - VERSION=1.4
+  - VERSION=1.3
+
+install:
+  - git clone https://github.com/docker-library/official-images.git ~/official-images
+
+before_script:
+  - env | sort
+  - cd "$VERSION"
+  - image="elasticsearch:$VERSION"
+
+script:
+  - docker build -t "$image" .
+  - ~/official-images/test/run.sh "$image"
+
+# vim:set et ts=2 sw=2:

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -2,20 +2,24 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
+ENV ELASTICSEARCH_MAJOR 1.3
 ENV ELASTICSEARCH_VERSION 1.3.9
 
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/$ELASTICSEARCH_MAJOR/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 
-RUN apt-get update \
-	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -8,7 +8,11 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV ELASTICSEARCH_VERSION 1.3.9
 

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -4,8 +4,8 @@ FROM java:8-jre
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN arch="$(dpkg --print-architecture)" \
 	&& set -x \
-	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -1,18 +1,14 @@
 FROM java:7-jre
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
 	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
-RUN set -xe \
-	&& for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_VERSION 1.3.9
 

--- a/1.3/docker-entrypoint.sh
+++ b/1.3/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.4.4
+ENV ELASTICSEARCH_VERSION 1.4.5
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,18 +1,14 @@
 FROM java:7-jre
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
 	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
-RUN set -xe \
-	&& for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_VERSION 1.4.4
 

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -4,8 +4,8 @@ FROM java:8-jre
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN arch="$(dpkg --print-architecture)" \
 	&& set -x \
-	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,5 +1,13 @@
 FROM java:7-jre
 
+# grab gosu for easy step-down from root
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_VERSION 1.4.4
@@ -15,7 +23,10 @@ COPY config /usr/share/elasticsearch/config
 
 VOLUME /usr/share/elasticsearch/data
 
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 EXPOSE 9200 9300
 
 CMD ["elasticsearch"]
-

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -8,7 +8,11 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV ELASTICSEARCH_VERSION 1.4.4
 

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -2,20 +2,24 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
+ENV ELASTICSEARCH_MAJOR 1.4
 ENV ELASTICSEARCH_VERSION 1.4.5
 
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/$ELASTICSEARCH_MAJOR/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 
-RUN apt-get update \
-	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.4/build.sh
+++ b/1.4/build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
-
-docker build --no-cache=true -t stefanofontanelli/elasticsearch .
-docker push stefanofontanelli/elasticsearch:latest
-docker tag -f stefanofontanelli/elasticsearch:latest stefanofontanelli/elasticsearch:1.4.4
-docker push stefanofontanelli/elasticsearch:1.4.4

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -8,7 +8,11 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV ELASTICSEARCH_VERSION 1.5.1
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -4,8 +4,8 @@ FROM java:8-jre
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN arch="$(dpkg --print-architecture)" \
 	&& set -x \
-	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.5.0
+ENV ELASTICSEARCH_VERSION 1.5.1
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,18 +1,14 @@
 FROM java:7-jre
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
 	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
-RUN set -xe \
-	&& for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_VERSION 1.5.1
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -2,20 +2,24 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
+ENV ELASTICSEARCH_MAJOR 1.5
 ENV ELASTICSEARCH_VERSION 1.5.2
 
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/$ELASTICSEARCH_MAJOR/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 
-RUN apt-get update \
-	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.5.1
+ENV ELASTICSEARCH_VERSION 1.5.2
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,0 +1,32 @@
+FROM java:7-jre
+
+# grab gosu for easy step-down from root
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+
+ENV ELASTICSEARCH_VERSION 1.5.0
+
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+
+RUN apt-get update \
+	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+COPY config /usr/share/elasticsearch/config
+
+VOLUME /usr/share/elasticsearch/data
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 9200 9300
+
+CMD ["elasticsearch"]

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -29,7 +29,7 @@ COPY config /usr/share/elasticsearch/config
 RUN /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.4.1 \
     && /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head \
     && /usr/share/elasticsearch/bin/plugin -install lukas-vlcek/bigdesk \
-    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.2
+    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.5.0
 
 COPY docker-entrypoint.sh /
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,4 +1,5 @@
 FROM java:8-jre
+VOLUME ["/usr/share/elasticsearch/config", "/usr/share/elasticsearch/data"]
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -21,7 +22,10 @@ RUN apt-get update \
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 COPY config /usr/share/elasticsearch/config
 
-VOLUME /usr/share/elasticsearch/data
+RUN /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.4.1 \
+    && /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head \
+    && /usr/share/elasticsearch/bin/plugin -install lukas-vlcek/bigdesk \
+    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.2
 
 COPY docker-entrypoint.sh /
 

--- a/1.5/config/logging.yml
+++ b/1.5/config/logging.yml
@@ -1,0 +1,15 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,14 +1,14 @@
 FROM java:8-jre
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
 	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_VERSION 1.6.0
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -4,8 +4,8 @@ FROM java:8-jre
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN arch="$(dpkg --print-architecture)" \
 	&& set -x \
-	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.6.1
+ENV ELASTICSEARCH_VERSION 1.6.2
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -2,20 +2,24 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
+ENV ELASTICSEARCH_MAJOR 1.6
 ENV ELASTICSEARCH_VERSION 1.6.2
 
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/$ELASTICSEARCH_MAJOR/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 
-RUN apt-get update \
-	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.6.0
+ENV ELASTICSEARCH_VERSION 1.6.1
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,0 +1,32 @@
+FROM java:7-jre
+
+# grab gosu for easy step-down from root
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+
+ENV ELASTICSEARCH_VERSION 1.6.0
+
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+
+RUN apt-get update \
+	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+COPY config /usr/share/elasticsearch/config
+
+VOLUME /usr/share/elasticsearch/data
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 9200 9300
+
+CMD ["elasticsearch"]

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,4 +1,5 @@
 FROM java:8-jre
+VOLUME ["/usr/share/elasticsearch/config", "/usr/share/elasticsearch/data"]
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -21,7 +22,10 @@ RUN apt-get update \
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 COPY config /usr/share/elasticsearch/config
 
-VOLUME /usr/share/elasticsearch/data
+RUN /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.4.1 \
+    && /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head \
+    && /usr/share/elasticsearch/bin/plugin -install lukas-vlcek/bigdesk \
+    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.2
 
 COPY docker-entrypoint.sh /
 

--- a/1.6/config/logging.yml
+++ b/1.6/config/logging.yml
@@ -1,0 +1,15 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/1.6/docker-entrypoint.sh
+++ b/1.6/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -2,20 +2,24 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
+ENV ELASTICSEARCH_MAJOR 1.7
 ENV ELASTICSEARCH_VERSION 1.7.1
 
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/$ELASTICSEARCH_MAJOR/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 
-RUN apt-get update \
-	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,0 +1,32 @@
+FROM java:8-jre
+
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+
+ENV ELASTICSEARCH_VERSION 1.7.0
+
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+
+RUN apt-get update \
+	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+COPY config /usr/share/elasticsearch/config
+
+VOLUME /usr/share/elasticsearch/data
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 9200 9300
+
+CMD ["elasticsearch"]

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -4,8 +4,8 @@ FROM java:8-jre
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN arch="$(dpkg --print-architecture)" \
 	&& set -x \
-	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.7.0
+ENV ELASTICSEARCH_VERSION 1.7.1
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,4 +1,5 @@
 FROM java:8-jre
+VOLUME ["/usr/share/elasticsearch/config", "/usr/share/elasticsearch/data"]
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -25,7 +26,10 @@ RUN set -x \
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 COPY config /usr/share/elasticsearch/config
 
-VOLUME /usr/share/elasticsearch/data
+RUN /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.4.1 \
+    && /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head \
+    && /usr/share/elasticsearch/bin/plugin -install lukas-vlcek/bigdesk \
+    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.2
 
 COPY docker-entrypoint.sh /
 

--- a/1.7/config/logging.yml
+++ b/1.7/config/logging.yml
@@ -1,0 +1,15 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/1.7/docker-entrypoint.sh
+++ b/1.7/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,11 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV ELASTICSEARCH_VERSION %%VERSION%%
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,8 +4,8 @@ FROM java:8-jre
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN arch="$(dpkg --print-architecture)" \
 	&& set -x \
-	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
+	&& curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,18 +1,14 @@
 FROM java:7-jre
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
 	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV GPG_KEYS 46095ACC8548582C1A2699A9D27D666CD88E42B4
-RUN set -xe \
-	&& for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV ELASTICSEARCH_VERSION %%VERSION%%
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,20 +2,24 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN arch="$(dpkg --print-architecture)" \
+	&& set -x \
+	&& curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$arch.asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION %%VERSION%%
+ENV ELASTICSEARCH_MAJOR %%ELASTICSEARCH_MAJOR%%
+ENV ELASTICSEARCH_VERSION %%ELASTICSEARCH_VERSION%%
 
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/$ELASTICSEARCH_MAJOR/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 
-RUN apt-get update \
-	&& apt-get install elasticsearch=$ELASTICSEARCH_VERSION \
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,7 +10,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 1.3.9
+ENV ELASTICSEARCH_VERSION %%VERSION%%
 
 RUN echo "deb http://packages.elasticsearch.org/elasticsearch/${ELASTICSEARCH_VERSION%.*}/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,8 +2,8 @@ FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -29,7 +29,7 @@ COPY config /usr/share/elasticsearch/config
 RUN /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.4.1 \
     && /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head \
     && /usr/share/elasticsearch/bin/plugin -install lukas-vlcek/bigdesk \
-    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.2
+    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.5.0
 
 COPY docker-entrypoint.sh /
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,5 @@
 FROM java:8-jre
+VOLUME ["/usr/share/elasticsearch/config", "/usr/share/elasticsearch/data"]
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -21,7 +22,10 @@ RUN apt-get update \
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 COPY config /usr/share/elasticsearch/config
 
-VOLUME /usr/share/elasticsearch/data
+RUN /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.4.1 \
+    && /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head \
+    && /usr/share/elasticsearch/bin/plugin -install lukas-vlcek/bigdesk \
+    && /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.2
 
 COPY docker-entrypoint.sh /
 

--- a/LICENSE
+++ b/LICENSE
@@ -176,18 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2013-2015 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ set -o pipefail
 [ $# -ne 1 ] && echo "usage: ./build.sh <version>" && exit 1
 VERSION="$1"
 MAJOR=${VERSION%%??}  # clearly.
+mkdir -p "$MAJOR"
 sed 's/%%VERSION%%/'"$VERSION"'/g' Dockerfile.template > "$MAJOR"/Dockerfile
 
 pushd "$MAJOR"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,5 @@ mkdir -p "$MAJOR"
 sed -e 's/%%ELASTICSEARCH_VERSION%%/'"$VERSION"'/g' -e 's/%%ELASTICSEARCH_MAJOR%%/'"$MAJOR"'/g' Dockerfile.template > "$MAJOR"/Dockerfile
 
 pushd "$MAJOR"
-docker build --no-cache=true -t stefanofontanelli/elasticsearch .
-docker tag -f stefanofontanelli/elasticsearch:latest stefanofontanelli/elasticsearch:"$VERSION"
-docker push stefanofontanelli/elasticsearch:latest
-docker push stefanofontanelli/elasticsearch:"$VERSION"
+docker build --no-cache=true -t gild/elasticsearch:"$VERSION" .
+docker push gild/elasticsearch:"$VERSION"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+
+[ $# -ne 1 ] && echo "usage: ./build.sh <version>" && exit 1
+VERSION="$1"
+MAJOR=${VERSION%%??}  # clearly.
+sed 's/%%VERSION%%/'"$VERSION"'/g' Dockerfile.template > "$MAJOR"/Dockerfile
+
+pushd "$MAJOR"
+docker build --no-cache=true -t stefanofontanelli/elasticsearch .
+docker tag -f stefanofontanelli/elasticsearch:latest stefanofontanelli/elasticsearch:"$VERSION"
+docker push stefanofontanelli/elasticsearch:latest
+docker push stefanofontanelli/elasticsearch:"$VERSION"

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ set -o pipefail
 VERSION="$1"
 MAJOR=${VERSION%%??}  # clearly.
 mkdir -p "$MAJOR"
-sed 's/%%VERSION%%/'"$VERSION"'/g' Dockerfile.template > "$MAJOR"/Dockerfile
+sed -e 's/%%ELASTICSEARCH_VERSION%%/'"$VERSION"'/g' -e 's/%%ELASTICSEARCH_MAJOR%%/'"$MAJOR"'/g' Dockerfile.template > "$MAJOR"/Dockerfile
 
 pushd "$MAJOR"
 docker build --no-cache=true -t stefanofontanelli/elasticsearch .

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+if [ "$1" = 'elasticsearch' ]; then
+	# Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+	chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+	exec gosu elasticsearch "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -15,7 +15,7 @@ url='git://github.com/docker-library/elasticsearch'
 echo '# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)'
 
 for version in "${versions[@]}"; do
-	commit="$(git log -1 --format='format:%H' -- "$version")"
+	commit="$(cd "$version" && git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
 	fullVersion="$(grep -m1 'ENV ELASTICSEARCH_VERSION' "$version/Dockerfile" | cut -d' ' -f3)"
 	
 	versionAliases=()

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,7 @@ set -e
 
 declare -A aliases
 aliases=(
-	[1.4]='1 latest'
+	[1.6]='1 latest'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,7 @@ set -e
 
 declare -A aliases
 aliases=(
-	[1.6]='1 latest'
+	[1.7]='1 latest'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"

--- a/update.sh
+++ b/update.sh
@@ -3,26 +3,30 @@ set -e
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-versions=( */ )
+versions=( "$@" )
+if [ ${#versions[@]} -eq 0 ]; then
+	versions=( */ )
+fi
 versions=( "${versions[@]%/}" )
-downloadable=$({
-	# get a few pages worth so we make sure to capture a decent number of releases
-	curl -fsSL 'https://www.elastic.co/downloads/past-releases'
-	curl -fsSL 'https://www.elastic.co/downloads/past-releases?page=2'
-	curl -fsSL 'https://www.elastic.co/downloads/past-releases?page=3'
-} | sed -rn 's!.*?/downloads/past-releases/(elasticsearch-)?[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\2!gp')
 
 travisEnv=
 for version in "${versions[@]}"; do
 	travisEnv='\n  - VERSION='"$version$travisEnv"
 	
-	recent=$(echo "$downloadable" | grep -m 1 "^$version" || true)
-	if [ -z "$recent" ]; then
+	fullVersion="$(curl -fsSL "http://packages.elasticsearch.org/elasticsearch/$version/debian/dists/stable/main/binary-amd64/Packages" | awk -F ': ' '$1 == "Package" { pkg = $2 } pkg == "elasticsearch" && $1 == "Version" { print $2 }' | sort -rV | head -n1)"
+	if [ -z "$fullVersion" ]; then
 		echo >&2 "warning: cannot find full version for $version"
 		continue
 	fi
-	sed 's/%%VERSION%%/'"$recent"'/' <Dockerfile.template >"$version/Dockerfile"
-	cp -p docker-entrypoint.sh $version
+	(
+		set -x
+		cp docker-entrypoint.sh Dockerfile.template "$version/"
+		mv "$version/Dockerfile.template" "$version/Dockerfile"
+		sed -i '
+			s/%%ELASTICSEARCH_MAJOR%%/'"$version"'/g;
+			s/%%ELASTICSEARCH_VERSION%%/'"$fullVersion"'/g;
+		' "$version/Dockerfile"
+	)
 done
 
 travis="$(awk -v 'RS=\n\n' '$1 == "env:" { $0 = "env:'"$travisEnv"'" } { printf "%s%s", $0, RS }' .travis.yml)"

--- a/update.sh
+++ b/update.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-downloadable=$(curl -sSL 'https://www.elastic.co/downloads/past-releases' | sed -rn 's!.*?/downloads/past-releases/[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\1!gp')
+downloadable=$(curl -sSL 'https://www.elastic.co/downloads/past-releases' | sed -rn 's!.*?/downloads/past-releases/(elasticsearch-)?[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\2!gp')
 
 for version in "${versions[@]}"; do
 	recent=$(echo "$downloadable" | grep -m 1 "$version")

--- a/update.sh
+++ b/update.sh
@@ -5,9 +5,10 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-downloadable=$(curl -sSL 'http://www.elasticsearch.org/downloads' | sed -rn 's!.*?http://www.elasticsearch.org/downloads/[0-9]+-[0-9]+-[0-9]+/">Download v ([0-9]+\.[0-9]+\.[0-9]+)<.*!\1!gp')
+downloadable=$(curl -sSL 'https://www.elastic.co/downloads/past-releases' | sed -rn 's!.*?/downloads/past-releases/[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\1!gp')
 
 for version in "${versions[@]}"; do
 	recent=$(echo "$downloadable" | grep -m 1 "$version")
-	sed -ri -e 's/^(ENV ELASTICSEARCH_VERSION) .*/\1 '"$recent"'/' "$version/Dockerfile"
+	sed 's/%%VERSION%%/'"$recent"'/' <Dockerfile.template >"$version/Dockerfile"
+	cp -p docker-entrypoint.sh $version
 done

--- a/update.sh
+++ b/update.sh
@@ -5,10 +5,25 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-downloadable=$(curl -sSL 'https://www.elastic.co/downloads/past-releases' | sed -rn 's!.*?/downloads/past-releases/(elasticsearch-)?[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\2!gp')
+downloadable=$({
+	# get a few pages worth so we make sure to capture a decent number of releases
+	curl -fsSL 'https://www.elastic.co/downloads/past-releases'
+	curl -fsSL 'https://www.elastic.co/downloads/past-releases?page=2'
+	curl -fsSL 'https://www.elastic.co/downloads/past-releases?page=3'
+} | sed -rn 's!.*?/downloads/past-releases/(elasticsearch-)?[0-9]+-[0-9]+-[0-9]+">Elasticsearch ([0-9]+\.[0-9]+\.[0-9]+)<.*!\2!gp')
 
+travisEnv=
 for version in "${versions[@]}"; do
-	recent=$(echo "$downloadable" | grep -m 1 "$version")
+	travisEnv='\n  - VERSION='"$version$travisEnv"
+	
+	recent=$(echo "$downloadable" | grep -m 1 "^$version" || true)
+	if [ -z "$recent" ]; then
+		echo >&2 "warning: cannot find full version for $version"
+		continue
+	fi
 	sed 's/%%VERSION%%/'"$recent"'/' <Dockerfile.template >"$version/Dockerfile"
 	cp -p docker-entrypoint.sh $version
 done
+
+travis="$(awk -v 'RS=\n\n' '$1 == "env:" { $0 = "env:'"$travisEnv"'" } { printf "%s%s", $0, RS }' .travis.yml)"
+echo "$travis" > .travis.yml


### PR DESCRIPTION
- merge from upstream
- add dockerfiles for versions 1.5 and 1.6.
- `build.sh` is now generalized, uses the template and create dockerfiles for specific versions
